### PR TITLE
PILOT-1139: Add total_per_zone property into statistics route

### DIFF
--- a/search/components/metadata_item/models.py
+++ b/search/components/metadata_item/models.py
@@ -80,3 +80,4 @@ class MetadataItemSizeStatistics(BaseModel):
 
     count: int
     size: int
+    count_by_zone: dict[int, int]

--- a/search/components/project_files/schemas.py
+++ b/search/components/project_files/schemas.py
@@ -41,6 +41,7 @@ class ProjectFilesTotalStatistics(BaseSchema):
 
     total_count: int
     total_size: int
+    total_per_zone: dict[int, int]
 
 
 class ProjectFilesTodayActivity(BaseSchema):

--- a/search/components/project_files/views.py
+++ b/search/components/project_files/views.py
@@ -81,6 +81,7 @@ async def get_project_statistics(
         files=ProjectFilesTotalStatistics(
             total_count=statistics.count,
             total_size=statistics.size,
+            total_per_zone=statistics.count_by_zone,
         ),
         activity=ProjectFilesTodayActivity(
             today_uploaded=transfer_statistics.uploaded,

--- a/tests/components/metadata_item/test_crud.py
+++ b/tests/components/metadata_item/test_crud.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import Counter
+
 from dateutil.relativedelta import relativedelta
 
 from search.components.metadata_item.filtering import MetadataItemProjectSizeUsageFiltering
@@ -132,7 +134,8 @@ class TestMetadataItemCRUD:
             3, type_=MetadataItemType.FILE, container_code=project_code, size=fake.pyint(1024**2, 1024**3)
         )
         expected_size = sum(item.size for item in created_metadata_items)
+        count_by_zone = Counter(item.zone for item in created_metadata_items)
 
         result = await metadata_item_crud.get_project_statistics(project_code)
 
-        assert result == MetadataItemSizeStatistics(count=3, size=expected_size)
+        assert result == MetadataItemSizeStatistics(count=3, size=expected_size, count_by_zone=count_by_zone)

--- a/tests/components/project_files/test_views.py
+++ b/tests/components/project_files/test_views.py
@@ -56,6 +56,7 @@ class TestProjectFilesViews:
             'files': {
                 'total_count': 1,
                 'total_size': created_metadata_item.size,
+                'total_per_zone': {str(created_metadata_item.zone): 1},
             },
             'activity': {
                 'today_uploaded': 1,


### PR DESCRIPTION
## Summary

Add `total_per_zone` property into `/v1/project-files/<project-code>/statistics` route response.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1139

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No
