### PR TITLE
Fix: datasets activity logs API not handling null values in changes

### DIFF
--- a/search/components/dataset_activity/models.py
+++ b/search/components/dataset_activity/models.py
@@ -22,8 +22,8 @@ class DatasetActivityChange(BaseModel):
     """Dataset activity change model."""
 
     property: str
-    old_value: str
-    new_value: str
+    old_value: str | None
+    new_value: str | None
 
 
 class DatasetActivity(BaseModel):

--- a/search/components/dataset_activity/schemas.py
+++ b/search/components/dataset_activity/schemas.py
@@ -23,8 +23,8 @@ class DatasetActivityChangeSchema(BaseSchema):
     """Dataset activity change schema."""
 
     property: str
-    old_value: str
-    new_value: str
+    old_value: str | None
+    new_value: str | None
 
 
 class DatasetActivitySchema(BaseSchema):

--- a/tests/fixtures/components/dataset_activity.py
+++ b/tests/fixtures/components/dataset_activity.py
@@ -47,7 +47,7 @@ class DatasetActivityFactory(BaseFactory):
             activity_time = self.fake.past_datetime()
 
         if container_code is ...:
-            container_code = self.fake.unique.word().lower()
+            container_code = self.fake.unique.word().lower() + self.fake.unique.word().lower()
 
         if version is ...:
             version = f'{self.fake.pyint(0, 4)}.{self.fake.pyint(0, 20)}'


### PR DESCRIPTION
## Summary

`old_value` and `new_value` could be `null`

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)
